### PR TITLE
feat(security): CORS solo en Gateway + aislamiento de microservicios + docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,37 +1,89 @@
 # Cloud Gateway - Documentación
 
 ## Objetivo
+
 Este microservicio actúa como puerta de entrada (API Gateway) para el ecosistema de microservicios del proyecto de inventario. Centraliza el enrutamiento, CORS, descubrimiento de servicios vía Eureka y la exposición de métricas.
 
 ## Puntos de entrada (Entry Points)
+
 - `CloudGatewayApplication.java`: Clase principal que arranca Spring Boot y habilita el cliente de descubrimiento (`@EnableDiscoveryClient`). Lee la variable de entorno `PROFILE` para activar un `spring.profiles.active` dinámico.
 - Puerto expuesto: Controlado por la variable de entorno `SERVER_PORT` (ver `application.yml`). En docker-compose.dev.yml actualmente mapeado a `8762`.
 
 ## Archivos importantes
 
-| Archivo | Descripción |
-|---------|------------|
-| `pom.xml` | Dependencias del Gateway (Spring Cloud Gateway, Eureka Client, Actuator, DevTools). Atención: define `<java.version>23</java.version>` (ver sección de notas). |
-| `Dockerfile` | Imagen multi-stage: construye el JAR con Maven y luego crea una imagen ligera con Temurin JDK para ejecutar `app.jar`. |
-| `src/main/resources/application.yml` | Configuración de: nombre de la app (`spring.application.name`), Gateway (discovery locator, filtros por defecto, CORS global), Actuator (exposición de endpoints), Eureka Client y puerto del servidor. Usa variables de entorno externas para parametrizar. |
-| `.env` / `test.env` | Variables de entorno (en producción se recomienda usar `.env.template` sin valores sensibles). |
-| `docker-compose.dev.yml` (en carpeta superior) | Orquesta los servicios: PostgreSQL (db), operador, buscador, eureka y este gateway. Actualmente no incluye Elasticsearch (agregar si procede). |
+| Archivo                                        | Descripción                                                                                                                                                                                                                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pom.xml`                                      | Dependencias del Gateway (Spring Cloud Gateway, Eureka Client, Actuator, DevTools). Atención: define `<java.version>23</java.version>` (ver sección de notas).                                                                                               |
+| `Dockerfile`                                   | Imagen multi-stage: construye el JAR con Maven y luego crea una imagen ligera con Temurin JDK para ejecutar `app.jar`.                                                                                                                                       |
+| `src/main/resources/application.yml`           | Configuración de: nombre de la app (`spring.application.name`), Gateway (discovery locator, filtros por defecto, CORS global), Actuator (exposición de endpoints), Eureka Client y puerto del servidor. Usa variables de entorno externas para parametrizar. |
+| `.env` / `test.env`                            | Variables de entorno (en producción se recomienda usar `.env.template` sin valores sensibles).                                                                                                                                                               |
+| `docker-compose.dev.yml` (en carpeta superior) | Orquesta los servicios: PostgreSQL (db), operador, buscador, eureka y este gateway. Actualmente no incluye Elasticsearch (agregar si procede).                                                                                                               |
 
 ## Variables de entorno usadas (referenciadas en `application.yml`)
-| Variable | Rol |
-|----------|-----|
-| `SERVER_NAME` | Nombre lógico de la app para Eureka y logs. |
-| `ALLOWED_ORIGINS` | Orígenes permitidos en CORS. Puede ser `*` o dominios específicos. |
+
+| Variable               | Rol                                                                |
+| ---------------------- | ------------------------------------------------------------------ |
+| `SERVER_NAME`          | Nombre lógico de la app para Eureka y logs.                        |
+| `ALLOWED_ORIGINS`      | Orígenes permitidos en CORS. Puede ser `*` o dominios específicos. |
 | `ROUTE_TABLES_ENABLED` | Habilita el endpoint actuator de gateway (visualización de rutas). |
-| `SERVER_PORT` | Puerto de escucha del gateway dentro del contenedor. |
-| `EUREKA_URL` | URL base del servidor Eureka para el registro y descubrimiento. |
-| `PROFILE` | (Opcional) Activa un perfil de Spring diferente al `default`. |
+| `SERVER_PORT`          | Puerto de escucha del gateway dentro del contenedor.               |
+| `EUREKA_URL`           | URL base del servidor Eureka para el registro y descubrimiento.    |
+| `PROFILE`              | (Opcional) Activa un perfil de Spring diferente al `default`.      |
 
 ## CORS
+
 Configurado de forma global bajo `spring.cloud.gateway.globalcors.cors-configurations`. Ajustar `ALLOWED_ORIGINS` para entornos de producción (evitar `"*"`).
 
+El CORS se gestiona exclusivamente en el API Gateway. Los microservicios no exponen puertos al host; solo el Gateway publica 8762.
+
+      globalcors:
+        corsConfigurations:
+          "[/**]":
+            # Orígenes permitidos (coma-separados). Fallback seguro en dev:
+            allowedOrigins: ${ALLOWED_ORIGINS:http://localhost:5050,http://localhost:3000}
+            allowedMethods: [GET, POST, PUT, DELETE, PATCH, OPTIONS]
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
+
+Prod: cambia ALLOWED_ORIGINS al dominio HTTPS del front (p. ej. https://app.tu-dominio.com).
+Si se permiten previews de Vercel, usar allowedOriginPatterns y patrones controlados.
+
+Aislamiento en Docker Compose
+ms-search:
+expose: ["8081"] # sin ports (no público)
+ms-operator:
+expose: ["8082"] # sin ports (no público)
+ms-cloud-gateway:
+ports: ["8762:8762"] # único puerto público
+
+## Pruebas rápidas
+
+# Preflight permitido (origen en ALLOWED_ORIGINS)
+
+curl -i -X OPTIONS "http://localhost:8762/ms-search/v1/items" \
+ -H "Origin: http://localhost:5050" \
+ -H "Access-Control-Request-Method: GET"
+
+# Preflight bloqueado (origen no permitido)
+
+curl -i -X OPTIONS "http://localhost:8762/ms-search/v1/items" \
+ -H "Origin: https://no-autorizado.com" \
+ -H "Access-Control-Request-Method: GET"
+
+# Acceso directo a microservicios (debe FALLAR)
+
+curl -i http://localhost:8081/v1/items
+curl -i http://localhost:8082/
+
+# Acceso vía Gateway (debe FUNCIONAR)
+
+curl -i http://localhost:8762/ms-search/v1/items
+
 ## Descubrimiento de servicios
+
 El bloque:
+
 ```yaml
 spring:
 	cloud:
@@ -41,15 +93,19 @@ spring:
 					enabled: true
 					lower-case-service-id: true
 ```
+
 permite que el gateway cree rutas dinámicas basadas en los IDs de los servicios registrados en Eureka. Ejemplo: si `ms-search` se registra como `ms-search`, una petición a `http://GATEWAY_HOST/ms-search/**` se enrutará al backend correspondiente.
 
 ## Filtros globales
+
 `default-filters` incluye `DedupeResponseHeader` para evitar duplicados en cabeceras CORS.
 
 ## Actuator
+
 Todos los endpoints están expuestos (`management.endpoints.web.exposure.include: "*"`). En producción se recomienda restringirlos (`health,info`).
 
 ## Flujo de enrutamiento (simplificado)
+
 1. Cliente (front) hace petición al Gateway.
 2. Gateway resuelve la ruta (estática o vía discovery locator + Eureka).
 3. Aplica filtros (CORS, deduplicación de cabeceras, etc.).
@@ -57,7 +113,9 @@ Todos los endpoints están expuestos (`management.endpoints.web.exposure.include
 5. Devuelve respuesta al cliente.
 
 ## Integración en docker-compose (desarrollo)
+
 Fragmento relevante (ya existente en `docker-compose.dev.yml` dentro de `cloud-gateway`):
+
 ```yaml
 	ms-cloud-gateway:
 		build:
@@ -75,12 +133,15 @@ Fragmento relevante (ya existente en `docker-compose.dev.yml` dentro de `cloud-g
 			- ms-search
 			- ms-operator
 ```
+
 La red `ms-project` permite que el gateway resuelva los hosts internos (por ejemplo `ms-eureka:8761`).
 
 ## Modo de desarrollo recomendado (compose + watch + rebuild)
+
 Se ha configurado `develop.watch` en el `docker-compose.dev.yml` para que **cada cambio en el código fuente (`src`) provoque un rebuild completo** de la imagen del microservicio correspondiente. Esto garantiza que el código Java se compile de nuevo y evita inconsistencias con DevTools cuando no se generan `.class` nuevos.
 
-### Archivo  `docker-compose.dev.yml`
+### Archivo `docker-compose.dev.yml`
+
 ```yaml
 
 	ms-operator:
@@ -137,64 +198,73 @@ Se ha configurado `develop.watch` en el `docker-compose.dev.yml` para que **cada
 ```
 
 ### Comando de arranque en modo watch
+
 ```bash
 docker compose -f cloud-gateway/docker-compose.dev.yml watch
 ```
 
 Al guardar un archivo bajo `src` en cualquiera de los servicios:
+
 1. Compose detecta el cambio y reconstruye la imagen (action: rebuild).
 2. Se recrea el contenedor con el nuevo código.
 3. El endpoint expone la versión actualizada (ejemplo: `/dev/reload-test`).
 
 ### Ventajas / Desventajas
-| Ventaja | Desventaja |
-|---------|------------|
-| Garantiza recompilación limpia | Lento si hay muchos módulos |
+
+| Ventaja                         | Desventaja                                       |
+| ------------------------------- | ------------------------------------------------ |
+| Garantiza recompilación limpia  | Lento si hay muchos módulos                      |
 | Evita inconsistencias de clases | El rebuild descarga dependencias si cambian poms |
-| Un flujo unificado para todos | Mayor consumo de CPU/IO durante rebuild |
+| Un flujo unificado para todos   | Mayor consumo de CPU/IO durante rebuild          |
 
 ### Alternativa (más rápida)
+
 Usar bind mounts + compilación local (`./mvnw -q -DskipTests compile`) montando `target/classes` y dejando DevTools reiniciar. Esta opción reduce rebuilds pero requiere compilar fuera del contenedor.
 
 ## Cómo se enlazan los microservicios
-| Servicio | Nombre de contenedor | Función |
-|----------|----------------------|---------|
-| `ms-eureka` | Registro/Eureka | Proporciona descubrimiento de servicios. |
-| `ms-search` | Buscador | Indexa y sirve datos de búsqueda (futuro: Elasticsearch). |
-| `ms-operator` | Operador | Operaciones CRUD/negocio principal (usa PostgreSQL). |
-| `db` | PostgreSQL | Base de datos para `ms-operator`. |
-| `ms-cloud-gateway` | Gateway | Entrada única para el front-end. |
+
+| Servicio           | Nombre de contenedor | Función                                                   |
+| ------------------ | -------------------- | --------------------------------------------------------- |
+| `ms-eureka`        | Registro/Eureka      | Proporciona descubrimiento de servicios.                  |
+| `ms-search`        | Buscador             | Indexa y sirve datos de búsqueda (futuro: Elasticsearch). |
+| `ms-operator`      | Operador             | Operaciones CRUD/negocio principal (usa PostgreSQL).      |
+| `db`               | PostgreSQL           | Base de datos para `ms-operator`.                         |
+| `ms-cloud-gateway` | Gateway              | Entrada única para el front-end.                          |
 
 El gateway utiliza Eureka para localizar `ms-search` y `ms-operator`. Las rutas pueden consumirse vía: `http://localhost:8762/ms-search/...` o `http://localhost:8762/ms-operator/...` (según configuración de discovery locator y naming).
 
 ## Ejecución (modo actual sin watch / hot reload)
+
 Desde el directorio `cloud-gateway` (o raíz ajustando la ruta), ejecutar:
+
 ```bash
 docker compose -f docker-compose.dev.yml up --build
 ```
+
 Esto construirá las imágenes y levantará todos los contenedores.
 
 ## Posible mejora: modo desarrollo con DevTools / watch
+
 1. Añadir perfiles `dev` y `prod` en `application.yml` o archivos separados.
 2. Usar `spring-boot-devtools` (ya añadido) + montar el código fuente como volumen.
 3. (Opcional) Crear `Dockerfile.dev` que ejecute `mvn spring-boot:run` y usar `develop.watch` de Docker Compose (si versión soporta) para sincronizar cambios.
 
 ## Notas sobre la versión de Java
+
 El `pom.xml` fija `<java.version>23</java.version>`. Asegúrate de que la imagen base (`eclipse-temurin:24-jdk`) soporta la compilación y que tu entorno local tiene JDK acorde. Si hay errores en otros módulos con JDKs diferentes, homogeneizar a LTS (17 o 21) puede ser recomendable.
 
 ## Buenas prácticas sugeridas
+
 - Restringir CORS a dominios concretos (e.g. front en producción).
 - Limitar endpoints de Actuator en producción.
 - Añadir rate limiting y filtros de seguridad (e.g. autenticación JWT) según evolucione el proyecto.
 - Crear un `README` general en la raíz describiendo cómo interactúa este gateway con los demás servicios.
 
 ## Troubleshooting rápido
-| Problema | Causa común | Solución |
-|----------|-------------|----------|
-| 404 al llamar a `ms-search` vía gateway | Servicio no registrado aún en Eureka | Esperar a registro (logs) o verificar `eureka.client.serviceUrl` |
-| CORS bloquea peticiones | `ALLOWED_ORIGINS` no incluye el front | Ajustar `.env` del gateway y reiniciar contenedor |
-| Cambios de código no reflejados | Imagen construida previamente | Reconstruir con `--build` o implementar modo dev |
-| Error de versión Java | JDK inconsistente entre módulos | Alinear `<java.version>` y base images |
 
-
-
+| Problema                                | Causa común                           | Solución                                                         |
+| --------------------------------------- | ------------------------------------- | ---------------------------------------------------------------- |
+| 404 al llamar a `ms-search` vía gateway | Servicio no registrado aún en Eureka  | Esperar a registro (logs) o verificar `eureka.client.serviceUrl` |
+| CORS bloquea peticiones                 | `ALLOWED_ORIGINS` no incluye el front | Ajustar `.env` del gateway y reiniciar contenedor                |
+| Cambios de código no reflejados         | Imagen construida previamente         | Reconstruir con `--build` o implementar modo dev                 |
+| Error de versión Java                   | JDK inconsistente entre módulos       | Alinear `<java.version>` y base images                           |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-
 services:
   db:
     image: postgres:16
@@ -25,8 +24,8 @@ services:
       - ../operator/.mvn:/app/.mvn
       - ../operator/mvnw:/app/mvnw
       - maven-repo-operator:/root/.m2
-    ports:
-      - "8082:8082"
+    expose:
+      - "8082"
     depends_on:
       - db
       - ms-eureka
@@ -38,6 +37,8 @@ services:
           path: ../operator/src
         - action: rebuild
           path: ../operator/pom.xml
+        - action: rebuild
+          path: ../operator/.env
 
   ms-search:
     build:
@@ -52,8 +53,8 @@ services:
       - ../search/.mvn:/app/.mvn
       - ../search/mvnw:/app/mvnw
       - maven-repo-search:/root/.m2
-    ports:
-      - "8081:8081"
+    expose:
+      - "8081"
     networks:
       - ms-project
     depends_on:
@@ -66,6 +67,8 @@ services:
           path: ../search/src
         - action: rebuild
           path: ../search/pom.xml
+        - action: rebuild
+          path: ../search/.env
 
   ms-eureka:
     build:
@@ -90,6 +93,8 @@ services:
           path: ../eureka/src
         - action: rebuild
           path: ../eureka/pom.xml
+        - action: rebuild
+          path: ../eureka/.env
 
   ms-cloud-gateway:
     build:
@@ -117,6 +122,8 @@ services:
           path: ./src
         - action: rebuild
           path: ./pom.xml
+        - action: rebuild
+          path: ./.env
 
 volumes:
   maven-repo-search:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,17 +9,16 @@ spring:
           lower-case-service-id: true
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
-      globalcors: ## CORS Configuration
+      globalcors:
         cors-configurations:
-          "[/**]": ## For all routes
-            allowedOrigins: ${ALLOWED_ORIGINS} # With '*' we allow all origins. We can restrict by indicating domains or ip + port, e.g. http://localhost:3000 (where our front is, or a Vercel domain)
-            allowedHeaders: "*" ## All headers allowed
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - DELETE
-              - PATCH
+          "[/**]":
+            # Permitir SOLO los orígenes definidos en ALLOWED_ORIGINS.
+            # Fallback seguro mientras desarrollas con Docker (front en 5050) o Vite (3000).
+            allowedOrigins: ${ALLOWED_ORIGINS:http://localhost:5050,http://localhost:3000}
+            allowedMethods: [GET, POST, PUT, DELETE, PATCH, OPTIONS]
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
 
 management:
   endpoint:


### PR DESCRIPTION
- Gateway: CORS global con ALLOWED_ORIGINS (preflight OPTIONS, DedupeResponseHeader)
- Compose (dev): ms-search/ms-operator sin puertos (expose), único público 8762
- Watch: rebuild al cambiar src/pom/.env en gateway, search y operator
- Docs: documentación añadida para CORS